### PR TITLE
Added functions to list vms and started libvirt documentation

### DIFF
--- a/README-libvirt.rst
+++ b/README-libvirt.rst
@@ -14,11 +14,40 @@ Working with Libvirt
     h.uri
     'qemu:///system'
 
-    # getting a list of all vms
+    # list all VMS
     h.list_all_vms
-    ['iptables-67b', 'katello_foreman',
-     'rhel7.1-yum-keepcache', 'fedora25', 'android']
+    [<NeosLibvirtVM (stopped): iptables-67b>,
+     <NeosLibvirtVM (stopped): katello_foreman>,
+     <NeosLibvirtVM (stopped): rhel7.1-yum-keepcache>,
+     <NeosLibvirtVM (running): android>]
 
-    # list with tuple objects from running vms
-    [('fedora25', <libvirt.virDomain at 0x7fdc9c068668>),
-     ('android', <libvirt.virDomain at 0x7fdc9c0659e8>)]
+    # list only stopped vms
+    h.list_all_vms
+    [<NeosLibvirtVM (stopped): iptables-67b>,
+     <NeosLibvirtVM (stopped): katello_foreman>,
+     <NeosLibvirtVM (stopped): rhel7.1-yum-keepcache>]
+
+    # list only running vms
+    h.list_running_vms
+    [<NeosLibvirtVM (running): android>]
+
+
+    # starting a VM
+    vm1 = h.get_vm('iptables-67b')
+
+    # checking vm status
+    vm1.status
+    'stopped'
+
+    # checking vm name
+    vm1.name
+    'iptables-67b'
+
+    # starting vm
+    vm1.start()
+    True
+
+    # checking vm status
+    vm1.status
+    'running'
+

--- a/README-libvirt.rst
+++ b/README-libvirt.rst
@@ -1,0 +1,24 @@
+Working with Libvirt
+--------------------
+
+.. code-block:: python
+
+    from neos.hypervisor.libvirt import NeosHypervisorLibvirt
+
+    # dbus authentication (default)
+    h = NeosHypervisorLibvirt()
+
+    h.family
+    'QUEMU'
+
+    h.uri
+    'qemu:///system'
+
+    # getting a list of all vms
+    h.list_all_vms
+    ['iptables-67b', 'katello_foreman',
+     'rhel7.1-yum-keepcache', 'fedora25', 'android']
+
+    # list with tuple objects from running vms
+    [('fedora25', <libvirt.virDomain at 0x7fdc9c068668>),
+     ('android', <libvirt.virDomain at 0x7fdc9c0659e8>)]

--- a/neos/hypervisor/libvirt.py
+++ b/neos/hypervisor/libvirt.py
@@ -2,6 +2,7 @@
 # vim:sw=4:ts=4:et:
 """Libvirt Hypervisor file."""
 import libvirt
+from libvirt import libvirtError
 
 from neos.utils import humanize_bytes
 from neos.hypervisor import NeosHypervisor
@@ -112,3 +113,29 @@ class NeosHypervisorLibvirt(NeosHypervisor):
         memory = self.instance.getMemoryStats(
             libvirt.VIR_NODE_MEMORY_STATS_ALL_CELLS)
         return humanize_bytes(memory['free'], unit)
+
+    @property
+    def list_all_vms(self):
+        """Return a list of all VMS."""
+        return self.instance.listDefinedDomains()
+
+    @property
+    def list_running_vms(self):
+        """List with all running vms (tuple vm name)."""
+        vms = []
+        for vm_id in self.instance.listDomainsID():
+            vm = self.instance.lookupByID(vm_id)
+            vms.append((vm.name(), vm))
+        return vms
+
+    @property
+    def list_nw_filters(self):
+        """Return a list of the network filter."""
+        return self.instance.listNWFilters()
+
+    def get_vm(self, name):
+        """Return VM object if exists."""
+        try:
+            return self.instance.lookupByName(name)
+        except libvirtError as error:
+            return error

--- a/neos/hypervisor/libvirt.py
+++ b/neos/hypervisor/libvirt.py
@@ -123,8 +123,8 @@ class NeosHypervisorLibvirt(NeosHypervisor):
     def list_stopped_vms(self):
         """Return a list of stopped VMS."""
         vms = []
-        for vm in self.instance.listDefinedDomains():
-            vms.append(NeosLibvirtVM(self.instance.lookupByName(vm)))
+        for vm_instance in self.instance.listDefinedDomains():
+            vms.append(NeosLibvirtVM(self.instance.lookupByName(vm_instance)))
         return vms
 
     @property
@@ -132,8 +132,8 @@ class NeosHypervisorLibvirt(NeosHypervisor):
         """Return a list of running vms."""
         vms = []
         for vm_id in self.instance.listDomainsID():
-            vm = self.instance.lookupByID(vm_id)
-            vms.append(NeosLibvirtVM(vm))
+            vm_instance = self.instance.lookupByID(vm_id)
+            vms.append(NeosLibvirtVM(vm_instance))
         return vms
 
     @property
@@ -159,7 +159,9 @@ class NeosLibvirtVM(object):
 
     def __repr__(self):
         """Define object representation."""
-        return "<{0} ({1}): {2}>".format(self.__class__.__name__, self.status, self.name)
+        return "<{0} ({1}): {2}>".format(self.__class__.__name__,
+                                         self.status,
+                                         self.name)
 
     def start(self):
         """Start virtual machine."""
@@ -176,7 +178,7 @@ class NeosLibvirtVM(object):
 
         [1,1] -> vm is running
         """
-        if bool(self._instance.state() == [1,1]):
+        if bool(self._instance.state() == [1, 1]):
             return 'running'
         else:
             return 'stopped'


### PR DESCRIPTION
```python
    from neos.hypervisor.libvirt import NeosHypervisorLibvirt

    # dbus authentication (default)
    h = NeosHypervisorLibvirt()

    h.family
    'QUEMU'

    h.uri
    'qemu:///system'

    # list all VMS
    h.list_all_vms
    [<NeosLibvirtVM (stopped): iptables-67b>,
     <NeosLibvirtVM (stopped): katello_foreman>,
     <NeosLibvirtVM (stopped): rhel7.1-yum-keepcache>,
     <NeosLibvirtVM (running): android>]

    # list only stopped vms
    h.list_all_vms
    [<NeosLibvirtVM (stopped): iptables-67b>,
     <NeosLibvirtVM (stopped): katello_foreman>,
     <NeosLibvirtVM (stopped): rhel7.1-yum-keepcache>]

    # list only running vms
    h.list_running_vms
    [<NeosLibvirtVM (running): android>]


    # starting a VM
    vm1 = h.get_vm('iptables-67b')

    # checking vm status
    vm1.status
    'stopped'

    # checking vm name
    vm1.name
    'iptables-67b'

    # starting vm
    vm1.start()
    True

    # checking vm status
    vm1.status
    'running'
```