### PR TITLE
 Removed libvirt-python from requirements to avoid breaking Travis

### DIFF
--- a/neos/hypervisor/libvirt.py
+++ b/neos/hypervisor/libvirt.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 # vim:sw=4:ts=4:et:
 """Libvirt Hypervisor file."""
-try:
-    import libvirt
-except ImportError:  # bypassing error for now due Travis tests
-    pass
+import libvirt
 
 from neos.utils import humanize_bytes
 from neos.hypervisor import NeosHypervisor

--- a/neos/hypervisor/libvirt.py
+++ b/neos/hypervisor/libvirt.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 # vim:sw=4:ts=4:et:
 """Libvirt Hypervisor file."""
-import libvirt
+try:
+    import libvirt
+except ImportError:  # bypassing error for now due Travis tests
+    pass
 
 from neos.utils import humanize_bytes
 from neos.hypervisor import NeosHypervisor

--- a/neos/macros.py
+++ b/neos/macros.py
@@ -28,3 +28,5 @@ PROJECT_CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
 ]
+
+PROJECT_REQUIREMENTS = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-libvirt-python

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from neos.macros import (
     __version__, PROJECT_AUTHOR, PROJECT_CLASSIFIERS, PROJECT_DESCRIPTION,
     PROJECT_EMAIL, PROJECT_KEYWORDS, PROJECT_LICENSE, PROJECT_NAME,
-    PROJECT_URL)
+    PROJECT_REQUIREMENTS, PROJECT_URL)
 
 from setuptools import setup
 
@@ -17,7 +17,7 @@ setup(
     url=PROJECT_URL,
     license=PROJECT_LICENSE,
     include_package_data=True,
-    install_requires=['libvirt-python'],
+    install_requires=PROJECT_REQUIREMENTS,
     test_suite='tests',
     keywords=PROJECT_KEYWORDS,
     classifiers=PROJECT_CLASSIFIERS,


### PR DESCRIPTION
```bash
  Complete output from command /home/travis/build/Aftermath/neos/.tox/lint/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-7vrtg9md/libvirt-python/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmptt7gawanpip-wheel- --python-tag cp34:
  Package libvirt was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libvirt.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libvirt' found
  Package libvirt was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libvirt.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libvirt' found
  running bdist_wheel
  running build
  /usr/bin/pkg-config --print-errors --atleast-version=0.9.11 libvirt
  Package libvirt was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libvirt.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libvirt' found
  error: command '/usr/bin/pkg-config' failed with exit status 1
```